### PR TITLE
Update python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        pip install build colorama
     - name: Build package
-      run: python -m build
+      run: python -m build -n
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:


### PR DESCRIPTION
installed colorama, disable build isolation

# the problem

an error was occuring since build created an isolated environment but since it does not use the setup.py, and it is the only container with dependencies, it did not know to install colorama.

# temporary solution

I disabled the virtual environment with the `-n` option and added *colorama* to pip install, so It won't show again.